### PR TITLE
User Management Updates

### DIFF
--- a/platform/lib/platform_web/components.ex
+++ b/platform/lib/platform_web/components.ex
@@ -2639,9 +2639,10 @@ defmodule PlatformWeb.Components do
   end
 
   def user_stack(assigns) do
-    assigns = assign_new(assigns, :dynamic, fn -> true end)
-              |>assign_new(:max, fn -> 5 end)
-              |> assign_new(:link_remaining_users, fn -> nil end)
+    assigns =
+      assign_new(assigns, :dynamic, fn -> true end)
+      |> assign_new(:max, fn -> 5 end)
+      |> assign_new(:link_remaining_users, fn -> nil end)
 
     ~H"""
     <div class="flex -space-x-1 relative z-0 place-items-end">
@@ -3667,7 +3668,11 @@ defmodule PlatformWeb.Components do
           </.link>
         <% end %>
         <div>
-          <.user_stack users={@project.memberships |> Enum.map(& &1.user)} link_remaining_users={"/projects/#{@project.id}/access"} size_classes="h-7 w-7" />
+          <.user_stack
+            users={@project.memberships |> Enum.map(& &1.user)}
+            link_remaining_users={"/projects/#{@project.id}/access"}
+            size_classes="h-7 w-7"
+          />
         </div>
       </div>
     </div>

--- a/platform/lib/platform_web/components.ex
+++ b/platform/lib/platform_web/components.ex
@@ -2639,7 +2639,9 @@ defmodule PlatformWeb.Components do
   end
 
   def user_stack(assigns) do
-    assigns = assign_new(assigns, :dynamic, fn -> true end) |> assign_new(:max, fn -> 5 end)
+    assigns = assign_new(assigns, :dynamic, fn -> true end)
+              |>assign_new(:max, fn -> 5 end)
+              |>assign(:project_id, Map.get(assigns, :project_id, nil))
 
     ~H"""
     <div class="flex -space-x-1 relative z-0 place-items-end">
@@ -2666,12 +2668,13 @@ defmodule PlatformWeb.Components do
         <% end %>
       <% end %>
       <%= if length(@users) > @max do %>
-        <div
-          class={"relative bg-gray-200 text-gray-700 text-xl rounded-full z-30 ring-2 flex items-center justify-center " <> Map.get(assigns, :size_classes, "h-5 w-5") <>" " <> Map.get(assigns, :ring_class, "ring-white")}
+        <.link
+          class={"relative block bg-gray-200 text-gray-700 text-xl rounded-full z-30 ring-2 flex items-center justify-center " <> Map.get(assigns, :size_classes, "h-5 w-5") <>" " <> Map.get(assigns, :ring_class, "ring-white")}
           data-tooltip={"Shared with #{length(@users) - 5} more user#{if length(@users) - 5 == 1, do: "", else: "s"}"}
+          navigate={if @project_id, do: "/projects/#{@project_id}/access", else: nil}
         >
           <Heroicons.ellipsis_horizontal mini class="h-4 w-4" />
-        </div>
+        </.link>
       <% end %>
     </div>
     """
@@ -3664,7 +3667,7 @@ defmodule PlatformWeb.Components do
           </.link>
         <% end %>
         <div>
-          <.user_stack users={@project.memberships |> Enum.map(& &1.user)} size_classes="h-7 w-7" />
+          <.user_stack users={@project.memberships |> Enum.map(& &1.user)} project_id={@project.id} size_classes="h-7 w-7" />
         </div>
       </div>
     </div>

--- a/platform/lib/platform_web/components.ex
+++ b/platform/lib/platform_web/components.ex
@@ -2641,7 +2641,7 @@ defmodule PlatformWeb.Components do
   def user_stack(assigns) do
     assigns = assign_new(assigns, :dynamic, fn -> true end)
               |>assign_new(:max, fn -> 5 end)
-              |>assign(:project_id, Map.get(assigns, :project_id, nil))
+              |> assign_new(:link_remaining_users, fn -> nil end)
 
     ~H"""
     <div class="flex -space-x-1 relative z-0 place-items-end">
@@ -2671,7 +2671,7 @@ defmodule PlatformWeb.Components do
         <.link
           class={"relative block bg-gray-200 text-gray-700 text-xl rounded-full z-30 ring-2 flex items-center justify-center " <> Map.get(assigns, :size_classes, "h-5 w-5") <>" " <> Map.get(assigns, :ring_class, "ring-white")}
           data-tooltip={"Shared with #{length(@users) - 5} more user#{if length(@users) - 5 == 1, do: "", else: "s"}"}
-          navigate={if @project_id, do: "/projects/#{@project_id}/access", else: nil}
+          navigate={@link_remaining_users}
         >
           <Heroicons.ellipsis_horizontal mini class="h-4 w-4" />
         </.link>
@@ -3667,7 +3667,7 @@ defmodule PlatformWeb.Components do
           </.link>
         <% end %>
         <div>
-          <.user_stack users={@project.memberships |> Enum.map(& &1.user)} project_id={@project.id} size_classes="h-7 w-7" />
+          <.user_stack users={@project.memberships |> Enum.map(& &1.user)} link_remaining_users={"/projects/#{@project.id}/access"} size_classes="h-7 w-7" />
         </div>
       </div>
     </div>

--- a/platform/lib/platform_web/live/settings_live/profile_component.ex
+++ b/platform/lib/platform_web/live/settings_live/profile_component.ex
@@ -46,6 +46,13 @@ defmodule PlatformWeb.SettingsLive.ProfileComponent do
     end
   end
 
+  def handle_event("remove_pfp", _params, socket) do
+    {:noreply,
+     socket
+     |> update_changeset(:profile_photo_file, "")
+     |> assign(:profile_photo_display, "")}
+  end
+
   def update_changeset(%{assigns: %{changeset: changeset}} = socket, key, value) do
     socket |> assign(:changeset, Ecto.Changeset.put_change(changeset, key, value))
   end
@@ -109,19 +116,33 @@ defmodule PlatformWeb.SettingsLive.ProfileComponent do
                     else: Routes.static_path(@socket, "/images/default_profile.jpg") %>
                 <img class="w-full h-full" src={photo} />
               </div>
-              <div>
-                <label for="profile_photo_file">
-                  <button
-                    class="button ~neutral ml-4"
-                    type="button"
-                    x-on:click="document.querySelector('input[name=\'profile_photo_file\']').click()"
-                    x-data
-                  >
-                    Change
-                  </button>
-                  <%= live_file_input(@uploads.profile_photo_file, class: "sr-only") %>
-                </label>
-                <%= hidden_input(f, :profile_photo_file) %>
+              <div class="grid md:grid-cols-2 gap-2 ml-4">
+                <div>
+                  <label for="profile_photo_file">
+                    <button
+                      class="button ~neutral"
+                      type="button"
+                      x-on:click="document.querySelector('input[name=\'profile_photo_file\']').click()"
+                      x-data
+                    >
+                      Change
+                    </button>
+                    <%= live_file_input(@uploads.profile_photo_file, class: "sr-only") %>
+                  </label>
+                  <%= hidden_input(f, :profile_photo_file) %>
+                </div>
+                <%= if (@profile_photo_display != "/images/default_profile.jpg") and (@profile_photo_display != "") do %>
+                  <label>
+                    <button
+                      class="button ~critical"
+                      type="button"
+                      phx-click="remove_pfp"
+                      phx-target={@myself}
+                    >
+                      Remove
+                    </button>
+                  </label>
+                <% end %>
               </div>
             </div>
             <%= for entry <- @uploads.profile_photo_file.entries do %>


### PR DESCRIPTION
#695 
#550 

This adds the ability to remove profile photos by switching the profile photo to default at the `settings` page, and links the ellipsis of `user_stack` to the project members page.

Relevant interface for removing profile photos:

![CleanShot 2023-10-05 at 12 31 00](https://github.com/atlosdotorg/atlos/assets/45888395/f8de3f79-8598-4624-a111-49139419cef9)