### PR TITLE
Fix tokens table size for medium screens 

### DIFF
--- a/platform/lib/platform_web/live/projects_live/api_tokens_component.ex
+++ b/platform/lib/platform_web/live/projects_live/api_tokens_component.ex
@@ -146,7 +146,7 @@ defmodule PlatformWeb.ProjectsLive.APITokensComponent do
             Use API tokens to connect your project to external services. You can create multiple tokens with different permissions.
           </p>
         </div>
-        <section class="flex flex-col mb-8 grow">
+        <section class="flex-1 flex flex-col mb-8 grow">
           <div class="flow-root">
             <div>
               <div class="inline-block min-w-full">


### PR DESCRIPTION
**Current**
The API Tokens table's width is too large relative to the other tables on the access page:
<img width="1046" alt="Screenshot 2024-09-01 at 11 40 32 PM" src="https://github.com/user-attachments/assets/afaf3f77-474b-4843-bdc2-fbfb3971df64">

**Change**
Adding `flex-1` to the tokens table `<section>` keeps the widths consistent.