### PR TITLE
Add basic incident sort functionality

### DIFF
--- a/platform/lib/platform/material/media_search.ex
+++ b/platform/lib/platform/material/media_search.ex
@@ -57,7 +57,9 @@ defmodule Platform.Material.MediaSearch do
       "modified_desc",
       "modified_asc",
       "description_desc",
-      "description_asc"
+      "description_asc",
+      "date_desc",
+      "date_asc"
     ])
   end
 
@@ -286,6 +288,12 @@ defmodule Platform.Material.MediaSearch do
 
           "description_asc" ->
             {queryable |> Ecto.Query.prepend_order_by([i], asc: i.attr_description), []}
+
+          "date_desc" ->
+            {queryable |> Ecto.Query.prepend_order_by([i], desc: i.attr_date), []}
+
+          "date_asc" ->
+            {queryable |> Ecto.Query.prepend_order_by([i], asc: i.attr_date), []}
         end
     end
   end

--- a/platform/lib/platform_web/components.ex
+++ b/platform/lib/platform_web/components.ex
@@ -2437,7 +2437,9 @@ defmodule PlatformWeb.Components do
                       "Recently Modified": :modified_desc,
                       "Least Recently Modified": :modified_asc,
                       "Description (A-Z)": :description_asc,
-                      "Description (Z-A)": :description_desc
+                      "Description (Z-A)": :description_desc,
+                      "Incident Date (Newest first)": :date_desc,
+                      "Incident Date (Oldest first)": :date_asc
                     ],
                     class:
                       "block bg-transparent w-full border-0 py-0 pl-0 pr-7 text-gray-900 placeholder-gray-500 focus:ring-0 sm:text-sm"


### PR DESCRIPTION
**Current**
We offer three sort options in search: 1) recently modified, 2) alphabetical incident description, and 3) recently created.

**Proposed**
Users would also like to be able to sort by incident date.

**Implementation notes**
There are two design decisions here:
1. First, how to name these options concisely? I decided to use "Incident Date (Most Recent)" and "Incident Date (Least Recent)". There may be a better name for each option.
2. Second, how to order incidents without a date? I've gone ahead with Ecto's default sorting for null values, but there may be an option that is preferable here.