### PR TITLE
Resolve uncaught URL parsing error by checking if host is nil when schema is not nil

### DIFF
--- a/platform/lib/platform/material/media.ex
+++ b/platform/lib/platform/material/media.ex
@@ -292,7 +292,7 @@ defmodule Platform.Material.Media do
   def validate_url_list(changeset, field) do
     valid? = fn url ->
       uri = URI.parse(url)
-      uri.scheme != nil && uri.host =~ "."
+      uri.scheme != nil && uri.host != nil && uri.host =~ "."
     end
 
     validate_change(changeset, field, fn field, value ->


### PR DESCRIPTION
We're seeing an uncaught URL-parsing error in which URL candidates with a non-nil `URI.schema` and a nil `URI.host` (such as `localhost:4000` raise a "no function clause matching in Kernel.=~/2" error because `validate_url_list/3` attempts to pattern-match against the nil `URI.host`.

This PR catches the error by confirming that the `URI.host` is not nil before attempting to pattern-match against it.