### PR TITLE
Fix httpps:// typo in API code example

### DIFF
--- a/docs/content/docs/Technical/api.md
+++ b/docs/content/docs/Technical/api.md
@@ -80,7 +80,7 @@ requests.get(
 
 ```python
 requests.get(
-    f"httpps://platform.atlos.org/api/v2/source_material",
+    f"https://platform.atlos.org/api/v2/source_material",
     headers={"Authorization": f"Bearer {api_token}"},
     params={"cursor": cursor},
 )


### PR DESCRIPTION
Line 83 of `docs/content/docs/Technical/api.md` has `httpps://platform.atlos.org/api/v2/source_material` (extra p) inside a Python code example. As written, the requests.get() call would fail with a connection error.

The 5 surrounding code blocks in the same file (lines 52, 71, 94, 108, 121) all use the correct `https://platform.atlos.org/api/v2/...` form. Verified the endpoint at `https://platform.atlos.org/api/v2/source_material` returns HTTP 401 (auth required), confirming it's the live API.