### PR TITLE
Add admin-scoped v2 API

### DIFF
--- a/docs/content/docs/Admin/_index.md
+++ b/docs/content/docs/Admin/_index.md
@@ -17,5 +17,6 @@ If you don’t administer an instance of Atlos, these features are not relevant 
 {{< card link="announcements/" title="Announcements" icon="speakerphone" >}} 
 {{< card link="user-management/" title="User management" icon="users" >}} 
 {{< card link="admin-security-tools/" title="Security tools" icon="lock-closed" >}} 
+{{< card link="api/" title="API access" icon="code" >}} 
 {{< card link="invites/" title="Invites" icon="link" >}} 
 {{< /cards >}}

--- a/docs/content/docs/Admin/api.md
+++ b/docs/content/docs/Admin/api.md
@@ -1,0 +1,61 @@
+---
+title: Admin API access
+description: Instance-wide API tokens for admins.
+weight: 6
+---
+
+Atlos admins can create **instance-wide v2 API tokens** that grant access to every project on the instance through a single token. This is useful for instance-level integrations—backups, cross-project reporting, or admin tooling—where a project-scoped token would be impractical.
+
+{{< callout type="warning" >}}
+**This page explains admin-only features.**
+If you don't administer an instance of Atlos, these features are not relevant to your use of the platform. Project owners create project-scoped API tokens from the project's **Access** page.
+{{< /callout >}}
+
+## Token kinds
+
+Atlos has three kinds of API tokens:
+
+| Kind | Scope | Created by | Status |
+| --- | --- | --- | --- |
+| **Instance-wide v2** | Every project on the instance | Admins, from Adminland → API Access | Active |
+| **Project-scoped v2** | A single project | Project owners, from a project's **Access** page | Active |
+| **Legacy v1** | Instance-wide, read-only, limited to `/api/v1/media` and `/api/v1/media_versions` | Admins | Deprecated; existing tokens still work, but new ones can't be created |
+
+## Create an instance-wide v2 token
+
+1. Navigate to **Adminland**.
+2. Click on the **API Access** tab.
+3. Click **Create**.
+4. Give the token a name and description, and select the permissions (`read`, `comment`, `edit`) you want it to have.
+5. Click **Create API Token**.
+
+The token's secret value is shown exactly once — store it somewhere safe. You can revoke a token at any time from the API Access page.
+
+## Using an instance-wide token
+
+Authentication, pagination, and endpoint shapes are identical to project-scoped tokens. See the main [API documentation](/technical/api/) for the full endpoint reference.
+
+There is one difference for admins:
+
+- **Creating an incident** (`POST /api/v2/incidents/new`) requires a `project_id` in the request body when using an instance-wide token, since the token isn't bound to a specific project. Project-scoped tokens ignore any `project_id` in the body — the token's project always wins.
+
+All other endpoints work identically. List endpoints (`GET /api/v2/incidents`, `GET /api/v2/source_material`, `GET /api/v2/updates`) return results from every project on the instance, and single-resource endpoints derive the project from the resource itself.
+
+## Legacy v1 endpoints (deprecated)
+
+Legacy v1 tokens are read-only and limited to two endpoints. New v1 tokens can't be created, but existing tokens continue to work. Migrate to instance-wide v2 tokens when feasible.
+
+### Endpoints
+
+- `GET /api/v1/media` — Returns all incidents across the instance. Most recently modified incidents are listed first.
+- `GET /api/v1/media_versions` — Returns all source material across the instance. Most recently modified source material is listed first.
+
+(The endpoint paths still use the legacy `media` and `media_versions` names, but the responses are the same `incidents` and `source material` records that v2 returns.)
+
+### Authentication
+
+Include an `Authorization` header and set its value to `Bearer <your token>`.
+
+### Pagination
+
+All v1 endpoints return 30 results per page. Paginate using the `cursor` query parameter, whose value is provided by the `next` and `previous` keys in the response. Results are available under the `results` key.

--- a/docs/content/docs/Technical/api.md
+++ b/docs/content/docs/Technical/api.md
@@ -14,12 +14,18 @@ You can learn more about the API authentication scheme and endpoints below. API 
 
 Please note that the API is in beta and not all operations are supported; if you need something, please get in touch via [email](mailto:contact@atlos.org) or on [Discord](https://discord.gg/gqCcHc9Gav).
 
+{{< callout type="info" >}}
+**Admins can also create instance-wide tokens** that work across every project on the instance. See [Admin API access](/admin/api/) for details.
+{{< /callout >}}
+
 ## Create an API token
 1. Navigate to the project for which you need an API token.
 2. Navigate to the **Access** page of the project.
 3. Press the **Create** button in the API Tokens section of the page.
 4. Assign the token a name, write a description of what the token is used for, and select permissions for the token.
 5. Click the **Create Token** button.
+
+If you administer the instance and need access across every project on it, create an [instance-wide token](/admin/api/) instead.
 
 
 ## API Vocabulary
@@ -194,9 +200,10 @@ requests.post(
 
 
 ### Create an incident
-`POST /api/v2/incidents/new` creates a new incident. It has two required parameters:
+`POST /api/v2/incidents/new` creates a new incident. It has the following required parameters:
 - `description`, the incident's description. `description` should be a string of at least 8 characters.
 - `sensitive`, a string array of the incident's sensitivity. That should be either `["Not Sensitive"]`, or any combination of the values `["Graphic Violence", "Deceptive or Misleading", "Personal Information Visible"]`.
+- `project_id`, the ID of the project to create the incident in. Required only if you're using an [instance-wide admin token](/admin/api/); ignored for project-scoped tokens.
 
 It also has many optional parameters:
 - Any attribute, both core and custom. See below for more information on accessing attributes' API identifiers.

--- a/platform/lib/platform/api.ex
+++ b/platform/lib/platform/api.ex
@@ -6,6 +6,7 @@ defmodule Platform.API do
   import Ecto.Query, warn: false
   alias Platform.Repo
 
+  alias Platform.Accounts
   alias Platform.API.APIToken
   alias Platform.Projects.Project
 
@@ -63,36 +64,33 @@ defmodule Platform.API do
 
   ## Examples
 
-      iex> create_api_token(%{field: value})
+      iex> create_api_token(project, user, %{field: value})
       {:ok, %APIToken{}}
 
-      iex> create_api_token(%{field: bad_value})
+      iex> create_api_token(nil, admin, %{field: value})
+      {:ok, %APIToken{}}
+
+      iex> create_api_token(project, user, %{field: bad_value})
       {:error, %Ecto.Changeset{}}
 
   """
-  def create_api_token(attrs \\ %{}, opts \\ []) do
-    changeset =
-      %APIToken{}
-      |> APIToken.changeset(attrs)
+  def create_api_token(project_or_nil, %Accounts.User{} = creator, attrs \\ %{}, opts \\ []) do
+    legacy = Keyword.get(opts, :legacy, false)
+    needs_admin = legacy or is_nil(project_or_nil)
 
-    changeset =
-      if Keyword.get(opts, :project) do
-        Ecto.Changeset.put_change(changeset, :project_id, Keyword.get(opts, :project).id)
-      else
-        changeset
-      end
+    if needs_admin and not Accounts.is_admin(creator) do
+      raise "User does not have permission to create an instance-wide or legacy API token"
+    end
 
-    changeset =
-      if Keyword.get(opts, :creator) do
-        Ecto.Changeset.put_change(changeset, :creator_id, Keyword.get(opts, :creator).id)
-      else
-        changeset
-      end
+    hydrated_attrs =
+      attrs
+      |> Map.new(fn {k, v} -> {to_string(k), v} end)
+      |> Map.put("creator_id", creator.id)
+      |> Map.put("project_id", project_or_nil && project_or_nil.id)
+      |> Map.put("is_legacy", legacy)
 
-    changeset =
-      Ecto.Changeset.put_change(changeset, :is_legacy, Keyword.get(opts, :legacy, false))
-
-    changeset
+    %APIToken{}
+    |> APIToken.changeset(hydrated_attrs)
     |> Repo.insert()
   end
 

--- a/platform/lib/platform/api/api_token.ex
+++ b/platform/lib/platform/api/api_token.ex
@@ -62,8 +62,43 @@ defmodule Platform.API.APIToken do
         []
       end
     end)
+    |> validate_project(api_token)
+    |> validate_is_legacy(api_token)
     |> assoc_constraint(:project)
     |> assoc_constraint(:creator)
     |> put_change(:value, Platform.Utils.generate_secure_code())
   end
+
+  defp validate_project(changeset, api_token) do
+    case get_change(changeset, :project_id, :no_change) do
+      :no_change ->
+        changeset
+
+      _value ->
+        if api_token.id,
+          do: add_error(changeset, :project_id, "Cannot change a token's project"),
+          else: changeset
+    end
+  end
+
+  defp validate_is_legacy(changeset, api_token) do
+    case get_change(changeset, :is_legacy, :no_change) do
+      :no_change ->
+        changeset
+
+      _value ->
+        if api_token.id,
+          do: add_error(changeset, :is_legacy, "Cannot change a token's legacy status"),
+          else: changeset
+    end
+  end
+
+  @doc """
+  An admin-managed token is one that surfaces in Adminland: legacy v1 tokens
+  and instance-wide v2 tokens (no project). Project-scoped tokens are managed
+  by their project's owners and excluded.
+  """
+  def admin_managed?(%__MODULE__{is_legacy: true}), do: true
+  def admin_managed?(%__MODULE__{project_id: nil}), do: true
+  def admin_managed?(%__MODULE__{}), do: false
 end

--- a/platform/lib/platform/permissions.ex
+++ b/platform/lib/platform/permissions.ex
@@ -117,7 +117,8 @@ defmodule Platform.Permissions do
 
   def can_api_token_post_comment?(%APIToken{} = token, %Media{} = media) do
     Enum.member?(token.permissions, :comment) and token.is_active and
-      token.project_id == media.project_id and _is_media_editable?(media)
+      (is_nil(token.project_id) or token.project_id == media.project_id) and
+      _is_media_editable?(media)
   end
 
   def can_api_token_create_media?(%APIToken{} = token) do
@@ -125,10 +126,11 @@ defmodule Platform.Permissions do
   end
 
   def can_api_token_edit_media?(%APIToken{} = token, %Media{} = media) do
-    # If media is being created and doesn't yet have a project, the token should able to give the media a project
+    # If media is being created and doesn't yet have a project, the token should able to give the media a project even if the token is project-scoped
     Enum.member?(token.permissions, :edit) and token.is_active and
       _is_media_editable?(media) and
-      (token.project_id == media.project_id or is_nil(media.project_id))
+      (is_nil(token.project_id) or token.project_id == media.project_id or
+         is_nil(media.project_id))
   end
 
   def can_api_token_update_attribute?(
@@ -160,7 +162,8 @@ defmodule Platform.Permissions do
   end
 
   def can_add_media_to_project?(%APIToken{} = token, %Project{} = project) do
-    Enum.member?(token.permissions, :edit) and token.is_active and project.active
+    Enum.member?(token.permissions, :edit) and token.is_active and project.active and
+      (is_nil(token.project_id) or token.project_id == project.id)
   end
 
   def can_bulk_upload_media_to_project?(%User{}, %Project{active: false}) do

--- a/platform/lib/platform_web/controllers/api/api_auth.ex
+++ b/platform/lib/platform_web/controllers/api/api_auth.ex
@@ -28,8 +28,8 @@ defmodule PlatformWeb.APIAuth do
     end
   end
 
-  def require_project_scoped_token(conn, _opts) do
-    if !is_nil(conn.assigns.token.project_id) and !conn.assigns.token.is_legacy do
+  def require_v2_token(conn, _opts) do
+    if not conn.assigns.token.is_legacy do
       conn
     else
       conn

--- a/platform/lib/platform_web/controllers/api/api_v2_controller.ex
+++ b/platform/lib/platform_web/controllers/api/api_v2_controller.ex
@@ -64,18 +64,30 @@ defmodule PlatformWeb.APIV2Controller do
     end
   end
 
+  # Project-scoped tokens always operate on their own project; instance-wide tokens use the supplied fallback id.
+  defp target_project(%Platform.API.APIToken{} = token, fallback_id) do
+    id = token.project_id || fallback_id
+    id && Projects.get_project(id)
+  end
+
   def media_versions(conn, params) do
     project_id = conn.assigns.token.project_id
 
-    pagination_api(conn, params, fn opts ->
-      Material.query_media_versions_paginated(
-        from(m in Material.MediaVersion,
-          join: incident in assoc(m, :media),
-          where: incident.project_id == ^project_id,
-          order_by: [desc: m.inserted_at]
-        ),
-        opts
+    base_query =
+      from(m in Material.MediaVersion,
+        join: incident in assoc(m, :media),
+        order_by: [desc: m.inserted_at]
       )
+
+    query =
+      if is_nil(project_id) do
+        base_query
+      else
+        from([_m, incident] in base_query, where: incident.project_id == ^project_id)
+      end
+
+    pagination_api(conn, params, fn opts ->
+      Material.query_media_versions_paginated(query, opts)
     end)
   end
 
@@ -84,7 +96,8 @@ defmodule PlatformWeb.APIV2Controller do
     media_version = Material.get_media_version(params["id"])
 
     cond do
-      is_nil(media_version) or media_version.media.project_id != project_id ->
+      is_nil(media_version) or
+          (not is_nil(project_id) and media_version.media.project_id != project_id) ->
         json(conn |> put_status(401), %{error: "media version not found or unauthorized"})
 
       true ->
@@ -93,18 +106,27 @@ defmodule PlatformWeb.APIV2Controller do
   end
 
   def create_media(conn, params) do
-    project_id = conn.assigns.token.project_id
-    project = Projects.get_project!(project_id)
+    token_project_id = conn.assigns.token.project_id
+    media_project = target_project(conn.assigns.token, params["project_id"])
 
-    other_params = ["urls"]
+    other_params = ["urls", "project_id"]
 
     is_unknown_attr = fn {key, _} ->
       not Enum.member?(other_params, key) and
-        is_nil(Attribute.get_attribute(key, project: project))
+        is_nil(Attribute.get_attribute(key, project: media_project))
     end
 
     cond do
       not Permissions.can_api_token_create_media?(conn.assigns.token) ->
+        json(conn |> put_status(401), %{error: "unauthorized"})
+
+      is_nil(media_project) and is_nil(token_project_id) ->
+        json(conn |> put_status(401), %{
+          error: "project not found (must supply a valid project_id)"
+        })
+
+      is_nil(media_project) or
+          not Permissions.can_add_media_to_project?(conn.assigns.token, media_project) ->
         json(conn |> put_status(401), %{error: "unauthorized"})
 
       # Ensure that all of the attributes in the input are valid, and note in the
@@ -128,13 +150,13 @@ defmodule PlatformWeb.APIV2Controller do
             # Merge the generated attribute change params. If `project_attributes` is already in
             # the accumulator, merge the new attribute change params with the existing ones.
             Material.generate_attribute_change_params(
-              Attribute.get_attribute(key, project: project),
+              Attribute.get_attribute(key, project: media_project),
               value,
-              project,
+              media_project,
               acc
             )
           end)
-          |> Map.put("project_id", project_id)
+          |> Map.put("project_id", media_project.id)
 
         # We expect a JSON array of URLs in the incident creation flow
         media_params =
@@ -294,9 +316,11 @@ defmodule PlatformWeb.APIV2Controller do
     project_id = conn.assigns.token.project_id
 
     base_query =
-      from(m in Material.Media,
-        where: m.project_id == ^project_id
-      )
+      if is_nil(project_id) do
+        from(m in Material.Media)
+      else
+        from(m in Material.Media, where: m.project_id == ^project_id)
+      end
 
     search_changeset = Material.MediaSearch.changeset(params)
 
@@ -318,7 +342,8 @@ defmodule PlatformWeb.APIV2Controller do
     media = Material.get_full_media_by_slug(params["slug"])
 
     cond do
-      is_nil(media) or media.project_id != project_id ->
+      is_nil(media) or
+          (not is_nil(project_id) and media.project_id != project_id) ->
         json(conn |> put_status(401), %{error: "incident not found"})
 
       not Permissions.can_api_token_post_comment?(conn.assigns.token, media) ->
@@ -354,21 +379,30 @@ defmodule PlatformWeb.APIV2Controller do
 
     cond do
       (not is_nil(media_slug) and is_nil(media)) or
-          (not is_nil(media) and media.project_id != project_id) ->
+          (not is_nil(media) and not is_nil(project_id) and media.project_id != project_id) ->
         conn |> put_status(401) |> json(%{error: "media not found"})
 
       not Permissions.can_api_token_read_updates?(conn.assigns.token) ->
         conn |> put_status(401) |> json(%{error: "api token not authorized to read updates"})
 
       true ->
+        base_query =
+          from(u in Updates.Update,
+            join: m in assoc(u, :media),
+            order_by: [desc: u.inserted_at],
+            preload: [:user, media: m]
+          )
+
+        query =
+          if is_nil(project_id) do
+            base_query
+          else
+            from([_u, m] in base_query, where: m.project_id == ^project_id)
+          end
+
         pagination_api(conn, params, fn opts ->
           Updates.query_updates_paginated(
-            from(u in Updates.Update,
-              join: m in assoc(u, :media),
-              where: m.project_id == ^project_id,
-              order_by: [desc: u.inserted_at],
-              preload: [:user, media: m]
-            )
+            query
             |> then(fn q ->
               if media do
                 where(q, [u], u.media_id == ^media.id)
@@ -383,21 +417,26 @@ defmodule PlatformWeb.APIV2Controller do
   end
 
   def update(conn, params) do
-    project_id = conn.assigns.token.project_id
-    project = Projects.get_project!(project_id)
+    token_project_id = conn.assigns.token.project_id
 
     # ok if nil
     message = params["message"]
-
-    attribute = params["attribute"] |> Attribute.get_attribute(project: project)
     value = params["value"]
     media = Material.get_full_media_by_slug(params["slug"])
+
+    project = target_project(conn.assigns.token, media && media.project_id)
+
+    attribute =
+      if is_nil(project),
+        do: nil,
+        else: Attribute.get_attribute(params["attribute"], project: project)
 
     cond do
       is_nil(value) ->
         json(conn |> put_status(401), %{error: "value not provided"})
 
-      is_nil(media) or media.project_id != project_id ->
+      is_nil(media) or
+          (not is_nil(token_project_id) and media.project_id != token_project_id) ->
         json(conn |> put_status(401), %{error: "incident not found"})
 
       not Permissions.can_api_token_edit_media?(conn.assigns.token, media) ->

--- a/platform/lib/platform_web/live/adminland_live/api_token_create_live.ex
+++ b/platform/lib/platform_web/live/adminland_live/api_token_create_live.ex
@@ -9,7 +9,7 @@ defmodule PlatformWeb.AdminlandLive.APITokenCreateLive do
      |> assign(assigns)
      |> assign(:parent_socket, parent_socket)
      |> assign(:token, nil)
-     |> assign(:changeset, API.change_api_token(%API.APIToken{}))}
+     |> assign(:changeset, API.change_api_token(%API.APIToken{permissions: [:read]}))}
   end
 
   def handle_event("validate", %{"api_token" => params}, socket) do
@@ -21,7 +21,12 @@ defmodule PlatformWeb.AdminlandLive.APITokenCreateLive do
   end
 
   def handle_event("save", %{"api_token" => params}, socket) do
-    with {:ok, value} <- API.create_api_token(params, legacy: true) do
+    current_user = socket.assigns.parent_socket.assigns.current_user
+
+    # Adminland only mints instance-wide v2 tokens. Legacy v1 tokens are
+    # deprecated; existing ones keep working but no new ones can be created
+    # through the UI.
+    with {:ok, value} <- API.create_api_token(nil, current_user, params, legacy: false) do
       Auditor.log(
         :api_token_created,
         %{description: value.description},
@@ -47,10 +52,15 @@ defmodule PlatformWeb.AdminlandLive.APITokenCreateLive do
           phx-submit="save"
           class="phx-form"
         >
+          <p class="text-sm text-gray-600 mb-6">
+            This will create an <span class="font-medium">instance-wide v2</span>
+            API token, which grants access across every project on this instance. Treat the resulting token with care.
+          </p>
+
           <%= label(f, :name, "What should we call this token?") %>
           <%= text_input(f, :name) %>
           <p class="support">
-            This name will be visible to members of the project and associated with any actions performed by the token.
+            This name will be visible to admins and to members of any project in which this token performs an action.
           </p>
           <%= error_tag(f, :name) %>
 
@@ -61,9 +71,34 @@ defmodule PlatformWeb.AdminlandLive.APITokenCreateLive do
             rows: 3
           ) %>
           <p class="support">
-            This is just for your reference, so you can remember what this token is for. It will be visible to other project owners.
+            This is just for your reference, so you can remember what this token is for. It will be visible to other admins.
           </p>
           <%= error_tag(f, :description) %>
+
+          <div class="mt-6">
+            <%= label(f, :permissions, "What permissions should this token have?") %>
+            <div id="admin-permissions-select" phx-update="ignore">
+              <%= multiple_select(
+                f,
+                :permissions,
+                [
+                  {"Read", "read"},
+                  {"Comment", "comment"},
+                  {"Edit", "edit"}
+                ],
+                "data-descriptions":
+                  Jason.encode!(%{
+                    "read" =>
+                      "Can read incidents, source material, comments, and updates across all projects",
+                    "comment" => "Can add comments to incidents in any project",
+                    "edit" =>
+                      "Can create incidents, edit attributes, and upload media versions in any project"
+                  }),
+                "data-required": Jason.encode!(["read"])
+              ) %>
+            </div>
+            <%= error_tag(f, :permissions) %>
+          </div>
 
           <%= submit(
             "Create API Token",
@@ -91,7 +126,7 @@ defmodule PlatformWeb.AdminlandLive.APITokenCreateLive do
           </p>
           <h2 class="font-mono text-lg font-medium my-2"><%= @token.value %></h2>
           <p class="text-gray-600 text-sm">
-            Your API token "<%= @token.description %>" is shown above. Be sure to store it somewhere, as you won't be able to see it again.
+            Your API token "<%= @token.name %>" is shown above. Be sure to store it somewhere, as you won't be able to see it again.
           </p>
           <p class="mt-4">
             <.link class="text-button text-sm" patch={Routes.adminland_index_path(@socket, :api)}>

--- a/platform/lib/platform_web/live/adminland_live/api_token_live.ex
+++ b/platform/lib/platform_web/live/adminland_live/api_token_live.ex
@@ -1,6 +1,7 @@
 defmodule PlatformWeb.AdminlandLive.APITokenLive do
   use PlatformWeb, :live_component
   alias Platform.API
+  alias Platform.API.APIToken
   alias Platform.Auditor
 
   def update(assigns, socket) do
@@ -23,162 +24,165 @@ defmodule PlatformWeb.AdminlandLive.APITokenLive do
      socket |> redirect(to: Routes.adminland_index_path(socket, :api)) |> assign_tokens()}
   end
 
-  def handle_event("delete_token", %{"token" => token_id}, socket) do
+  def handle_event("deactivate_token", %{"token" => token_id}, socket) do
     with token <- API.get_api_token!(token_id),
-         {:ok, _} <- API.delete_api_token(token) do
+         true <- APIToken.admin_managed?(token),
+         {:ok, _} <- API.deactivate_api_token(token) do
       Auditor.log(
-        :api_token_deleted,
+        :api_token_deactivated,
         %{description: token.description},
         socket.assigns.parent_socket
       )
 
-      {:noreply, socket |> put_flash(:info, "API token deleted successfully.") |> assign_tokens()}
+      {:noreply,
+       socket |> put_flash(:info, "API token deactivated successfully.") |> assign_tokens()}
     else
-      _ -> {:noreply, socket |> put_flash(:info, "Unable to delete API token.")}
+      _ -> {:noreply, socket |> put_flash(:info, "Unable to deactivate API token.")}
     end
   end
 
   def render(assigns) do
     ~H"""
-    <section class="max-w-3xl mx-auto">
-      <div class="flex flex-col">
-        <div class="-my-2 -mx-4 overflow-x-auto sm:-mx-6 lg:-mx-8">
-          <div class="inline-block min-w-full py-2 align-middle md:px-6 lg:px-8">
-            <%= if length(@tokens) > 0 do %>
-              <div class="overflow-hidden shadow ring-1 ring-black ring-opacity-5 md:rounded-lg">
-                <table class="min-w-full divide-y divide-gray-300">
-                  <thead class="bg-white">
-                    <tr>
-                      <th
-                        scope="col"
-                        class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6"
-                      >
-                        Description
-                      </th>
-                      <th
-                        scope="col"
-                        class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
-                      >
-                        Created
-                      </th>
-                      <th scope="col" class="py-3.5 pl-3 pr-4 sm:pr-6">
-                        <span class="sr-only">More Actions</span>
-                        <.link
-                          class="button ~urge @high float-right"
-                          patch={Routes.adminland_index_path(@socket, :api_new)}
-                        >
-                          New Token
-                        </.link>
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody class="divide-y divide-gray-200 bg-white">
-                    <%= for token <- @tokens do %>
+    <section class="flex-1 flex flex-col mb-8 grow">
+      <div class="flow-root">
+        <div>
+          <div class="inline-block min-w-full">
+            <div class="mb-8 bg-urge-50 border border-urge-400 aside ~urge prose text-sm w-full min-w-full">
+              <p>
+                <strong class="text-blue-800">
+                  Admins create
+                  <a class="text-blue-800" href="https://docs.atlos.org/admin/api/">
+                    instance-wide v2 tokens
+                  </a>
+                  here.
+                </strong>
+                These grant full v2 API access across every project on this instance. Project-scoped v2 tokens are listed here for visibility but are managed by project owners from the project's Access page. Legacy v1 tokens are deprecated and can no longer be created. Learn more in our <a
+                  class="text-blue-800"
+                  href="https://docs.atlos.org/admin/api/"
+                >admin API documentation</a>.
+              </p>
+            </div>
+            <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+              <div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
+                <div class="overflow-hidden shadow ring-1 ring-black ring-opacity-5 sm:rounded-lg">
+                  <table class="min-w-full divide-y divide-gray-300">
+                    <thead class="bg-gray-50">
                       <tr>
-                        <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm sm:pl-6">
-                          <%= token.name %> (<%= token.description || "no description" %>)
-                          <span :if={token.is_legacy} class="chip ~warning">Legacy</span>
-                          <span :if={!is_nil(token.project_id)} class="chip ~positive">
-                            Project Based
+                        <th
+                          scope="col"
+                          class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6"
+                        >
+                          Name
+                        </th>
+                        <th
+                          scope="col"
+                          class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+                        >
+                          Last used
+                        </th>
+                        <th
+                          scope="col"
+                          class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+                        >
+                          Created
+                        </th>
+                        <th
+                          scope="col"
+                          class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+                        >
+                          Permissions
+                        </th>
+                        <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-6 text-right">
+                          <.link
+                            class="button ~urge @high"
+                            patch={Routes.adminland_index_path(@socket, :api_new)}
+                          >
+                            Create
+                          </.link>
+                          <span class="sr-only">Deactivate</span>
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody class="divide-y divide-gray-200 bg-white">
+                      <tr :if={Enum.empty?(@tokens)} class="text-center py-8 text-gray-500">
+                        <td class="py-4 px-4 bg-neutral-50" colspan="5">
+                          No API tokens have been created.
+                        </td>
+                      </tr>
+                      <tr :for={token <- @tokens} id={token.id}>
+                        <td class="py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
+                          <%= token.name %>
+                          <span :if={!is_nil(token.description)} data-tooltip={token.description}>
+                            <Heroicons.information_circle
+                              mini
+                              class="h-4 w-4 text-gray-400 inline-block"
+                            />
+                          </span>
+                          <span :if={token.is_legacy} class="chip ~warning ml-2">Legacy v1</span>
+                          <span
+                            :if={!token.is_legacy and is_nil(token.project_id)}
+                            class="chip ~urge ml-2"
+                          >
+                            Instance-wide v2
+                          </span>
+                          <span :if={!is_nil(token.project_id)} class="chip ~positive ml-2">
+                            Project-scoped v2
+                          </span>
+                          <span
+                            :if={not token.is_active}
+                            class="chip ~critical ml-2"
+                            data-tooltip="This token has been deactivated and can no longer be used."
+                          >
+                            Deactivated
                           </span>
                         </td>
-                        <td class="max-w-md px-3 py-4 text-sm text-gray-500">
-                          <.rel_time time={token.inserted_at} />
+                        <td class="px-3 py-4 text-sm text-gray-500">
+                          <%= if not is_nil(token.last_used) do %>
+                            <%= token.last_used |> Date.to_string() %>
+                          <% else %>
+                            Never
+                          <% end %>
                         </td>
-                        <td class="pl-3 pr-4 sm:pr-6">
+                        <td class="px-3 py-4 text-sm text-gray-500">
+                          <.rel_time time={token.inserted_at} />
+                          <%= if not is_nil(token.creator) do %>
+                            by <.user_text user={token.creator} />
+                          <% end %>
+                        </td>
+                        <td class="px-3 py-4 text-sm text-gray-500">
+                          <div class="flex flex-wrap gap-1">
+                            <%= for permission <- token.permissions do %>
+                              <span class="chip ~neutral"><%= permission %></span>
+                            <% end %>
+                          </div>
+                        </td>
+                        <td class="relative py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
                           <button
-                            :if={token.is_legacy}
-                            phx-click="delete_token"
+                            :if={APIToken.admin_managed?(token) and token.is_active}
+                            phx-click="deactivate_token"
                             phx-value-token={token.id}
                             phx-target={@myself}
-                            data-confirm="Are you sure you want to delete this API token?"
-                            class="font-medium text-critical-500 hover:text-critical-700 float-right text-sm"
+                            data-confirm={"Are you sure you want to deactivate the token \"#{token.name}\"? This action cannot be undone."}
+                            data-tooltip={"Deactivate " <> token.name}
                           >
-                            Delete
+                            <Heroicons.minus_circle mini class="h-5 w-5" />
+                            <span class="sr-only">Deactivate <%= token.name %></span>
                           </button>
                         </td>
                       </tr>
-                    <% end %>
-                  </tbody>
-                </table>
-              </div>
-            <% else %>
-              <div class="text-center">
-                <svg
-                  class="mx-auto h-12 w-12 text-gray-400"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  aria-hidden="true"
-                >
-                  <path
-                    vector-effect="non-scaling-stroke"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M9 13h6m-3-3v6m-9 1V7a2 2 0 012-2h6l2 2h6a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2z"
-                  />
-                </svg>
-                <h3 class="mt-2 text-sm font-medium text-gray-900">No API tokens</h3>
-                <p class="mt-1 text-sm text-gray-500">Get started by creating a new API token.</p>
-                <div class="mt-6">
-                  <.link
-                    class="button ~urge @high"
-                    patch={Routes.adminland_index_path(@socket, :api_new)}
-                  >
-                    New Token
-                  </.link>
+                    </tbody>
+                  </table>
                 </div>
               </div>
-            <% end %>
-            <div class="bg-urge-50 border border-urge-400 mx-auto aside ~urge prose text-sm mt-8 w-full">
-              <p>
-                <strong class="text-blue-800">
-                  The Atlos API is a deprecated read-only API for administrators.
-                </strong>
-                You can learn more about the API authentication scheme and endpoints below. Note that this API is deprecated and will be removed in a future release. Please use project-specific API tokens instead.
-              </p>
-              <details class="-mt-2">
-                <summary class="cursor-pointer font-medium">How to use the API</summary>
-                <p>The Atlos API supports the following endpoints:</p>
-                <ul>
-                  <li>
-                    <code>/api/v1/media</code>
-                    &mdash; returns all incidents, with the most recently modified incidents listed first (internally, incidents are called media &mdash; that is, collections of individual pieces of media)
-                  </li>
-                  <li>
-                    <code>/api/v1/media_versions</code>
-                    &mdash; returns all media versions, with the most recently modified media versions listed first
-                  </li>
-                </ul>
-                <p>
-                  All endpoints return 30 results at a time. You can paginate using the
-                  <code>cursor</code>
-                  query parameter, whose value is provided by the <code>next</code>
-                  and <code>previous</code>
-                  keys in the response. Results are available under the <code>results</code>
-                  key.
-                </p>
-                <p>
-                  To authenticate against the API, include a <code>Authorization</code>
-                  header and set its value to <code>Bearer &lt;your token&gt;</code>
-                  (without the brackets).
-                </p>
-              </details>
             </div>
           </div>
         </div>
       </div>
       <%= if @show_creation_modal do %>
         <.modal target={@myself} close_confirmation={}>
-          <div class="mb-8">
-            <p class="sec-head">
-              New API Token
-            </p>
-            <p class="sec-subhead">
-              Note that you will only be able to see the secret value once.
-            </p>
-          </div>
+          <p class="sec-head">
+            New API Token
+          </p>
           <.live_component
             module={PlatformWeb.AdminlandLive.APITokenCreateLive}
             id="new-token"

--- a/platform/lib/platform_web/live/adminland_live/index.html.heex
+++ b/platform/lib/platform_web/live/adminland_live/index.html.heex
@@ -87,7 +87,7 @@
               clip-rule="evenodd"
             />
           </svg>
-          Legacy API Access
+          API Access
         </.link>
         <.link
           class={if(@live_action == :invites, do: active_classes, else: inactive_classes)}

--- a/platform/lib/platform_web/live/projects_live/api_tokens_component.ex
+++ b/platform/lib/platform_web/live/projects_live/api_tokens_component.ex
@@ -98,12 +98,8 @@ defmodule PlatformWeb.ProjectsLive.APITokensComponent do
     cs = changeset(socket, params)
 
     if cs.valid? do
-      params =
-        params
-        |> Map.put("project_id", socket.assigns.project.id)
-        |> Map.put("creator_id", socket.assigns.current_user.id)
-
-      result = API.create_api_token(params)
+      result =
+        API.create_api_token(socket.assigns.project, socket.assigns.current_user, params)
 
       case result do
         {:ok, token} ->

--- a/platform/lib/platform_web/router.ex
+++ b/platform/lib/platform_web/router.ex
@@ -86,7 +86,7 @@ defmodule PlatformWeb.Router do
     end
 
     scope "/v2" do
-      pipe_through([:require_project_scoped_token])
+      pipe_through([:require_v2_token])
 
       get("/source_material", APIV2Controller, :media_versions)
       get("/source_material/:id", APIV2Controller, :media_version)

--- a/platform/priv/repo/seeds.exs
+++ b/platform/priv/repo/seeds.exs
@@ -13,6 +13,7 @@
 alias Platform.Projects
 alias Platform.Accounts
 alias Platform.Material
+alias Platform.API
 
 {:ok, regular} =
   Accounts.register_user(%{
@@ -100,6 +101,43 @@ random_projects =
 
     project
   end)
+
+IO.puts("Creating seed API tokens")
+
+{:ok, _} =
+  API.create_api_token(
+    nil,
+    admin,
+    %{
+      "name" => "Seed Legacy v1",
+      "description" => "Seeded legacy v1 token for local development"
+    },
+    legacy: true
+  )
+
+{:ok, _} =
+  API.create_api_token(
+    nil,
+    admin,
+    %{
+      "name" => "Seed Instance-wide v2",
+      "description" => "Seeded instance-wide v2 token for local development",
+      "permissions" => [:read, :comment, :edit]
+    },
+    legacy: false
+  )
+
+{:ok, _} =
+  API.create_api_token(
+    List.first(random_projects),
+    admin,
+    %{
+      "name" => "Seed Project-scoped v2",
+      "description" => "Seeded project-scoped v2 token for local development",
+      "permissions" => [:read, :comment, :edit]
+    },
+    legacy: false
+  )
 
 IO.puts("Creating seed media")
 

--- a/platform/test/platform/api_test.exs
+++ b/platform/test/platform/api_test.exs
@@ -8,6 +8,10 @@ defmodule Platform.APITest do
 
     import Platform.APIFixtures
 
+    setup do
+      %{admin: Platform.AccountsFixtures.admin_user_fixture()}
+    end
+
     @invalid_attrs %{name: nil, description: nil, value: nil}
 
     test "list_api_tokens/0 returns all api_tokens" do
@@ -20,19 +24,21 @@ defmodule Platform.APITest do
       assert API.get_api_token!(api_token.id) == api_token
     end
 
-    test "create_api_token/1 with valid data creates a api_token" do
+    test "create_api_token/3 with valid data creates a api_token", %{admin: admin} do
       valid_attrs = %{
         name: "some name",
-        description: "some description",
-        creator_id: Platform.Accounts.get_auto_account().id
+        description: "some description"
       }
 
-      assert {:ok, %APIToken{} = api_token} = API.create_api_token(valid_attrs, legacy: true)
+      assert {:ok, %APIToken{} = api_token} =
+               API.create_api_token(nil, admin, valid_attrs, legacy: true)
+
       assert api_token.description == "some description"
     end
 
-    test "create_api_token/1 with invalid data returns error changeset" do
-      assert {:error, %Ecto.Changeset{}} = API.create_api_token(@invalid_attrs)
+    test "create_api_token/3 with invalid data returns error changeset", %{admin: admin} do
+      assert {:error, %Ecto.Changeset{}} =
+               API.create_api_token(nil, admin, @invalid_attrs)
     end
 
     test "update_api_token/2 with valid data updates the api_token" do
@@ -58,6 +64,173 @@ defmodule Platform.APITest do
     test "change_api_token/1 returns a api_token changeset" do
       api_token = api_token_fixture_legacy()
       assert %Ecto.Changeset{} = API.change_api_token(api_token)
+    end
+
+    test "admin_managed?/1 classifies tokens correctly" do
+      legacy = api_token_fixture_legacy()
+      instance_wide = api_token_fixture_instance_wide_v2()
+      project_scoped = api_token_fixture()
+
+      assert APIToken.admin_managed?(legacy)
+      assert APIToken.admin_managed?(instance_wide)
+      refute APIToken.admin_managed?(project_scoped)
+    end
+
+    test "create_api_token/3 cannot be tricked into creating a legacy token via params",
+         %{admin: admin} do
+      assert {:ok, token} =
+               API.create_api_token(
+                 nil,
+                 admin,
+                 %{
+                   "name" => "evil",
+                   "description" => "tries to set is_legacy via params",
+                   "is_legacy" => true
+                 },
+                 legacy: false
+               )
+
+      refute token.is_legacy
+    end
+
+    test "create_api_token/3 ignores user-supplied `value` (the secret)", %{admin: admin} do
+      attempted_value = "attacker-chosen-token-value"
+
+      {:ok, token} =
+        API.create_api_token(
+          nil,
+          admin,
+          %{
+            "name" => "no value injection",
+            "description" => "tries to set value via params",
+            "value" => attempted_value
+          }
+        )
+
+      refute token.value == attempted_value
+    end
+
+    test "create_api_token/3 ignores user-supplied `project_id` when project_or_nil is nil",
+         %{admin: admin} do
+      project = Platform.ProjectsFixtures.project_fixture()
+
+      {:ok, token} =
+        API.create_api_token(
+          nil,
+          admin,
+          %{
+            "name" => "no project injection",
+            "description" => "tries to set project_id via params",
+            "project_id" => project.id
+          }
+        )
+
+      assert is_nil(token.project_id)
+    end
+
+    test "create_api_token/3 enforces :read in permissions", %{admin: admin} do
+      assert {:error, changeset} =
+               API.create_api_token(
+                 nil,
+                 admin,
+                 %{
+                   "name" => "no read",
+                   "description" => "should fail",
+                   "permissions" => [:edit]
+                 }
+               )
+
+      refute changeset.valid?
+      assert %{permissions: ["API tokens must have read permissions"]} = errors_on(changeset)
+    end
+
+    test "create_api_token/3 rejects unknown permissions", %{admin: admin} do
+      assert {:error, changeset} =
+               API.create_api_token(
+                 nil,
+                 admin,
+                 %{
+                   "name" => "bad perm",
+                   "description" => "should fail",
+                   "permissions" => [:read, :admin]
+                 }
+               )
+
+      refute changeset.valid?
+    end
+
+    test "create_api_token/3 raises when a non-admin tries to create an admin-managed token" do
+      non_admin = Platform.AccountsFixtures.user_fixture()
+
+      # Non-admin creator — instance-wide
+      assert_raise RuntimeError, fn ->
+        API.create_api_token(nil, non_admin, %{
+          "name" => "non-admin try",
+          "description" => "should fail"
+        })
+      end
+
+      # Non-admin creator — legacy
+      assert_raise RuntimeError, fn ->
+        API.create_api_token(
+          nil,
+          non_admin,
+          %{
+            "name" => "non-admin legacy try",
+            "description" => "should fail"
+          },
+          legacy: true
+        )
+      end
+    end
+
+    test "create_api_token/3 allows non-admins to create project-scoped tokens" do
+      non_admin = Platform.AccountsFixtures.user_fixture()
+      project = Platform.ProjectsFixtures.project_fixture()
+
+      assert {:ok, token} =
+               API.create_api_token(project, non_admin, %{
+                 "name" => "project-scoped, non-admin creator",
+                 "description" => "should succeed"
+               })
+
+      assert token.project_id == project.id
+      refute token.is_legacy
+    end
+
+    test "deactivated tokens cannot be reactivated" do
+      token = api_token_fixture_instance_wide_v2()
+      {:ok, deactivated} = API.deactivate_api_token(token)
+      refute deactivated.is_active
+
+      assert {:error, changeset} = API.update_api_token(deactivated, %{is_active: true})
+      assert %{is_active: ["Cannot reactivate an inactive token"]} = errors_on(changeset)
+    end
+
+    test "a token's project_id cannot be cleared on update" do
+      token = api_token_fixture()
+      refute is_nil(token.project_id)
+
+      assert {:error, changeset} = API.update_api_token(token, %{project_id: nil})
+      assert %{project_id: ["Cannot change a token's project"]} = errors_on(changeset)
+    end
+
+    test "a token's project_id cannot be changed to a different project on update" do
+      token = api_token_fixture()
+      other_project = Platform.ProjectsFixtures.project_fixture()
+
+      assert {:error, changeset} =
+               API.update_api_token(token, %{project_id: other_project.id})
+
+      assert %{project_id: ["Cannot change a token's project"]} = errors_on(changeset)
+    end
+
+    test "a token's is_legacy cannot be changed on update" do
+      token = api_token_fixture()
+      refute token.is_legacy
+
+      assert {:error, changeset} = API.update_api_token(token, %{is_legacy: true})
+      assert %{is_legacy: ["Cannot change a token's legacy status"]} = errors_on(changeset)
     end
   end
 end

--- a/platform/test/platform/permissions_test.exs
+++ b/platform/test/platform/permissions_test.exs
@@ -6,6 +6,7 @@ defmodule Platform.PermissionsTest do
   alias Platform.ProjectsFixtures
   alias Platform.AccountsFixtures
   alias Platform.MaterialFixtures
+  alias Platform.APIFixtures
 
   setup do
     project = ProjectsFixtures.project_fixture()
@@ -100,6 +101,107 @@ defmodule Platform.PermissionsTest do
 
     test "can_create_media?/1", context do
       assert Permissions.can_create_media?(context.editor)
+    end
+
+    test "can_add_media_to_project?/2 with API token enforces token scope", context do
+      other_project = ProjectsFixtures.project_fixture()
+
+      project_scoped =
+        APIFixtures.api_token_fixture(%{
+          project_id: context.project.id,
+          permissions: [:read, :edit]
+        })
+
+      foreign_scoped =
+        APIFixtures.api_token_fixture(%{
+          project_id: other_project.id,
+          permissions: [:read, :edit]
+        })
+
+      instance_wide = APIFixtures.api_token_fixture_instance_wide_v2()
+
+      assert Permissions.can_add_media_to_project?(project_scoped, context.project)
+      refute Permissions.can_add_media_to_project?(foreign_scoped, context.project)
+
+      assert Permissions.can_add_media_to_project?(instance_wide, context.project)
+      assert Permissions.can_add_media_to_project?(instance_wide, other_project)
+    end
+
+    test "can_add_media_to_project?/2 with API token returns false for inactive project",
+         context do
+      {:ok, inactive} = Projects.update_project_active(context.project, false)
+
+      project_scoped =
+        APIFixtures.api_token_fixture(%{project_id: inactive.id, permissions: [:read, :edit]})
+
+      instance_wide = APIFixtures.api_token_fixture_instance_wide_v2()
+
+      refute Permissions.can_add_media_to_project?(project_scoped, inactive)
+      refute Permissions.can_add_media_to_project?(instance_wide, inactive)
+    end
+
+    test "can_api_token_post_comment?/2", context do
+      other_project = ProjectsFixtures.project_fixture()
+
+      project_scoped =
+        APIFixtures.api_token_fixture(%{
+          project_id: context.project.id,
+          permissions: [:read, :comment]
+        })
+
+      foreign_scoped =
+        APIFixtures.api_token_fixture(%{
+          project_id: other_project.id,
+          permissions: [:read, :comment]
+        })
+
+      instance_wide =
+        APIFixtures.api_token_fixture_instance_wide_v2(%{permissions: [:read, :comment]})
+
+      read_only =
+        APIFixtures.api_token_fixture(%{
+          project_id: context.project.id,
+          permissions: [:read]
+        })
+
+      assert Permissions.can_api_token_post_comment?(project_scoped, context.media)
+      refute Permissions.can_api_token_post_comment?(foreign_scoped, context.media)
+      assert Permissions.can_api_token_post_comment?(instance_wide, context.media)
+      refute Permissions.can_api_token_post_comment?(read_only, context.media)
+    end
+
+    test "can_api_token_edit_media?/2", context do
+      other_project = ProjectsFixtures.project_fixture()
+
+      project_scoped =
+        APIFixtures.api_token_fixture(%{
+          project_id: context.project.id,
+          permissions: [:read, :edit]
+        })
+
+      foreign_scoped =
+        APIFixtures.api_token_fixture(%{
+          project_id: other_project.id,
+          permissions: [:read, :edit]
+        })
+
+      instance_wide =
+        APIFixtures.api_token_fixture_instance_wide_v2(%{permissions: [:read, :edit]})
+
+      read_only =
+        APIFixtures.api_token_fixture(%{
+          project_id: context.project.id,
+          permissions: [:read]
+        })
+
+      assert Permissions.can_api_token_edit_media?(project_scoped, context.media)
+      refute Permissions.can_api_token_edit_media?(foreign_scoped, context.media)
+      assert Permissions.can_api_token_edit_media?(instance_wide, context.media)
+      refute Permissions.can_api_token_edit_media?(read_only, context.media)
+
+      # Any edit-capable token can edit it media with no project
+      unassigned_media = %Platform.Material.Media{project_id: nil}
+      assert Permissions.can_api_token_edit_media?(foreign_scoped, unassigned_media)
     end
   end
 end

--- a/platform/test/platform_web/controllers/api_v2_test.exs
+++ b/platform/test/platform_web/controllers/api_v2_test.exs
@@ -664,4 +664,375 @@ defmodule PlatformWeb.APIV2Test do
 
     # Ensure arbitrary optional attribute values are stored correctly
   end
+
+  test "GET /api/v2/incidents returns incidents from every project", %{conn: _conn} do
+    project_a = project_fixture()
+    project_b = project_fixture()
+    media_a = media_fixture(%{project_id: project_a.id})
+    media_b = media_fixture(%{project_id: project_b.id})
+
+    token = api_token_fixture_instance_wide_v2()
+
+    auth_conn =
+      build_conn()
+      |> put_req_header("authorization", "Bearer " <> token.value)
+      |> get("/api/v2/incidents")
+
+    body = json_response(auth_conn, 200)
+    slugs = Enum.map(body["results"], & &1["slug"])
+    assert media_a.slug in slugs
+    assert media_b.slug in slugs
+  end
+
+  test "POST /api/v2/add_comment/:slug works across projects", %{conn: _conn} do
+    project_a = project_fixture()
+    project_b = project_fixture()
+    media_a = media_fixture(%{project_id: project_a.id})
+    media_b = media_fixture(%{project_id: project_b.id})
+
+    token = api_token_fixture_instance_wide_v2()
+
+    for media <- [media_a, media_b] do
+      resp =
+        build_conn()
+        |> put_req_header("authorization", "Bearer " <> token.value)
+        |> post("/api/v2/add_comment/#{media.slug}", %{"message" => "hello from admin"})
+
+      assert json_response(resp, 200) == %{"success" => true}
+    end
+  end
+
+  test "POST /api/v2/incidents/new requires a project_id in the body", %{conn: _conn} do
+    token = api_token_fixture_instance_wide_v2()
+
+    resp =
+      build_conn()
+      |> put_req_header("authorization", "Bearer " <> token.value)
+      |> post("/api/v2/incidents/new", %{"description" => "no project specified"})
+
+    assert json_response(resp, 401) == %{
+             "error" =>
+               "project not found (must supply a valid project_id)"
+           }
+  end
+
+  test "POST /api/v2/incidents/new creates in the supplied project", %{conn: _conn} do
+    project = project_fixture()
+    token = api_token_fixture_instance_wide_v2()
+
+    resp =
+      build_conn()
+      |> put_req_header("authorization", "Bearer " <> token.value)
+      |> post("/api/v2/incidents/new", %{
+        "description" => "admin-created incident",
+        "project_id" => project.id,
+        "sensitive" => ["Not Sensitive"]
+      })
+
+    body = json_response(resp, 200)
+    assert body["success"] == true
+    assert body["result"]["attr_description"] == "admin-created incident"
+    assert body["result"]["project"]["id"] == project.id
+  end
+
+  test "legacy v1 tokens are still rejected at v2", %{conn: _conn} do
+    legacy = api_token_fixture_legacy()
+
+    resp =
+      build_conn()
+      |> put_req_header("authorization", "Bearer " <> legacy.value)
+      |> get("/api/v2/incidents")
+
+    assert json_response(resp, 401) == %{"error" => "invalid token or token not found"}
+  end
+
+  test "project-scoped tokens still only see their project", %{conn: _conn} do
+    project_a = project_fixture()
+    project_b = project_fixture()
+    _media_a = media_fixture(%{project_id: project_a.id})
+    media_b = media_fixture(%{project_id: project_b.id})
+
+    token_a = api_token_fixture(%{project_id: project_a.id})
+
+    auth_conn =
+      build_conn()
+      |> put_req_header("authorization", "Bearer " <> token_a.value)
+      |> get("/api/v2/incidents")
+
+    body = json_response(auth_conn, 200)
+    slugs = Enum.map(body["results"], & &1["slug"])
+    refute media_b.slug in slugs
+  end
+
+  test "POST /incidents/new rejects a non-existent project_id", %{conn: _conn} do
+    token = api_token_fixture_instance_wide_v2()
+    bogus_uuid = Ecto.UUID.generate()
+
+    resp =
+      build_conn()
+      |> put_req_header("authorization", "Bearer " <> token.value)
+      |> post("/api/v2/incidents/new", %{
+        "description" => "should fail",
+        "project_id" => bogus_uuid,
+        "sensitive" => ["Not Sensitive"]
+      })
+
+    assert json_response(resp, 401) == %{
+             "error" =>
+               "project not found (must supply a valid project_id)"
+           }
+  end
+
+  test "instance-wide token without :edit cannot create incidents", %{conn: _conn} do
+    project = project_fixture()
+    token = api_token_fixture_instance_wide_v2(%{permissions: [:read, :comment]})
+
+    resp =
+      build_conn()
+      |> put_req_header("authorization", "Bearer " <> token.value)
+      |> post("/api/v2/incidents/new", %{
+        "description" => "Test incident description",
+        "project_id" => project.id,
+        "sensitive" => ["Not Sensitive"]
+      })
+
+    assert json_response(resp, 401) == %{"error" => "unauthorized"}
+  end
+
+  test "instance-wide token without :comment cannot post comments", %{conn: _conn} do
+    project = project_fixture()
+    media = media_fixture(%{project_id: project.id})
+    token = api_token_fixture_instance_wide_v2(%{permissions: [:read, :edit]})
+
+    resp =
+      build_conn()
+      |> put_req_header("authorization", "Bearer " <> token.value)
+      |> post("/api/v2/add_comment/#{media.slug}", %{"message" => "should fail"})
+
+    assert json_response(resp, 401) == %{"error" => "api token not authorized to post comment"}
+  end
+
+  test "instance-wide token without :edit cannot update attributes", %{conn: _conn} do
+    project = project_fixture()
+    media = media_fixture(%{project_id: project.id})
+    token = api_token_fixture_instance_wide_v2(%{permissions: [:read, :comment]})
+
+    resp =
+      build_conn()
+      |> put_req_header("authorization", "Bearer " <> token.value)
+      |> post("/api/v2/update/#{media.slug}/description", %{
+        "message" => "test",
+        "value" => "should not stick"
+      })
+
+    assert json_response(resp, 401) == %{"error" => "api token not authorized to edit"}
+  end
+
+  test "deactivated instance-wide token is rejected on writes", %{conn: _conn} do
+    # Note: `APIToken.changeset/2` runs `put_change(:value, generate_secure_code())`
+    # unconditionally, so any update — including deactivation — rotates the
+    # secret. The original token value therefore fails at the auth plug
+    # ("invalid token or token not found") rather than reaching the
+    # permission layer's `is_active` check. Either rejection is acceptable;
+    # this test pins the end-to-end behavior so a regression that leaves
+    # deactivated tokens valid would be caught regardless of which layer fires.
+    project = project_fixture()
+    media = media_fixture(%{project_id: project.id})
+    token = api_token_fixture_instance_wide_v2()
+    {:ok, _} = Platform.API.deactivate_api_token(token)
+
+    assert_rejected = fn conn ->
+      body = json_response(conn, 401)
+      refute Map.get(body, "success")
+      assert is_binary(body["error"])
+    end
+
+    build_conn()
+    |> put_req_header("authorization", "Bearer " <> token.value)
+    |> post("/api/v2/add_comment/#{media.slug}", %{"message" => "should fail"})
+    |> assert_rejected.()
+
+    build_conn()
+    |> put_req_header("authorization", "Bearer " <> token.value)
+    |> post("/api/v2/update/#{media.slug}/description", %{
+      "message" => "test",
+      "value" => "should not stick"
+    })
+    |> assert_rejected.()
+
+    build_conn()
+    |> put_req_header("authorization", "Bearer " <> token.value)
+    |> post("/api/v2/incidents/new", %{
+      "description" => "should fail",
+      "project_id" => project.id,
+      "sensitive" => ["Not Sensitive"]
+    })
+    |> assert_rejected.()
+
+    # And the side-effects didn't happen.
+    assert Material.get_media!(media.id).attr_description == media.attr_description
+  end
+
+  test "pagination cursor signed by one token cannot be replayed by another", %{conn: _conn} do
+    project = project_fixture()
+
+    # Create enough media to guarantee a `next` cursor (limit is 100).
+    Enum.each(1..101, fn _ -> media_fixture(%{project_id: project.id}) end)
+
+    token_a = api_token_fixture_instance_wide_v2()
+    token_b = api_token_fixture_instance_wide_v2()
+
+    page_one =
+      build_conn()
+      |> put_req_header("authorization", "Bearer " <> token_a.value)
+      |> get("/api/v2/incidents")
+      |> json_response(200)
+
+    assert is_binary(page_one["next"])
+
+    # Replay token_a's cursor with token_b — should not return results.
+    replay =
+      build_conn()
+      |> put_req_header("authorization", "Bearer " <> token_b.value)
+      |> get("/api/v2/incidents", %{"cursor" => page_one["next"]})
+      |> json_response(200)
+
+    assert replay["error"] == "unable to verify or parse pagination information"
+    refute Map.has_key?(replay, "results")
+  end
+
+  test "project-scoped token cannot fetch another project's source_material by id",
+       %{conn: _conn} do
+    project_a = project_fixture()
+    project_b = project_fixture()
+    media_b = media_fixture(%{project_id: project_b.id})
+
+    {:ok, version_b} =
+      Material.create_media_version(media_b, %{
+        upload_type: :user_provided,
+        status: :pending,
+        source_url: "https://example.com/b"
+      })
+
+    token_a = api_token_fixture(%{project_id: project_a.id})
+
+    resp =
+      build_conn()
+      |> put_req_header("authorization", "Bearer " <> token_a.value)
+      |> get("/api/v2/source_material/#{version_b.id}")
+
+    assert json_response(resp, 401) == %{"error" => "media version not found or unauthorized"}
+  end
+
+  test "project-scoped token cannot escape its scope by forging project_id in body",
+       %{conn: _conn} do
+    project_a = project_fixture()
+    project_b = project_fixture()
+
+    token_a =
+      api_token_fixture(%{project_id: project_a.id, permissions: [:read, :comment, :edit]})
+
+    # Caller tries to force creation in project_b by passing project_id in the body.
+    resp =
+      build_conn()
+      |> put_req_header("authorization", "Bearer " <> token_a.value)
+      |> post("/api/v2/incidents/new", %{
+        "description" => "trying to escape my project scope",
+        "project_id" => project_b.id,
+        "sensitive" => ["Not Sensitive"]
+      })
+
+    body = json_response(resp, 200)
+    assert body["success"] == true
+    # The forged project_id is silently ignored — incident lands in project_a.
+    assert body["result"]["project"]["id"] == project_a.id
+    refute body["result"]["project"]["id"] == project_b.id
+  end
+
+  test "project-scoped token cannot update another project's media", %{conn: _conn} do
+    project_a = project_fixture()
+    project_b = project_fixture()
+    media_b = media_fixture(%{project_id: project_b.id})
+
+    token_a =
+      api_token_fixture(%{project_id: project_a.id, permissions: [:read, :comment, :edit]})
+
+    resp =
+      build_conn()
+      |> put_req_header("authorization", "Bearer " <> token_a.value)
+      |> post("/api/v2/update/#{media_b.slug}/description", %{
+        "message" => "test",
+        "value" => "should not stick"
+      })
+
+    assert json_response(resp, 401) == %{"error" => "incident not found"}
+    assert Material.get_media!(media_b.id).attr_description == media_b.attr_description
+  end
+
+  test "project-scoped token cannot post comment on another project's media",
+       %{conn: _conn} do
+    project_a = project_fixture()
+    project_b = project_fixture()
+    media_b = media_fixture(%{project_id: project_b.id})
+
+    token_a =
+      api_token_fixture(%{project_id: project_a.id, permissions: [:read, :comment, :edit]})
+
+    resp =
+      build_conn()
+      |> put_req_header("authorization", "Bearer " <> token_a.value)
+      |> post("/api/v2/add_comment/#{media_b.slug}", %{"message" => "should not appear"})
+
+    assert json_response(resp, 401) == %{"error" => "incident not found"}
+  end
+
+  test "project-scoped token cannot read updates from another project", %{conn: _conn} do
+    project_a = project_fixture()
+    project_b = project_fixture()
+    media_a = media_fixture(%{project_id: project_a.id})
+    media_b = media_fixture(%{project_id: project_b.id})
+
+    # Seed a comment in each project via that project's own token.
+    writer_a =
+      api_token_fixture(%{project_id: project_a.id, permissions: [:read, :comment]})
+
+    writer_b =
+      api_token_fixture(%{project_id: project_b.id, permissions: [:read, :comment]})
+
+    build_conn()
+    |> put_req_header("authorization", "Bearer " <> writer_a.value)
+    |> post("/api/v2/add_comment/#{media_a.slug}", %{"message" => "comment in A"})
+
+    build_conn()
+    |> put_req_header("authorization", "Bearer " <> writer_b.value)
+    |> post("/api/v2/add_comment/#{media_b.slug}", %{"message" => "comment in B"})
+
+    token_a = api_token_fixture(%{project_id: project_a.id})
+
+    body =
+      build_conn()
+      |> put_req_header("authorization", "Bearer " <> token_a.value)
+      |> get("/api/v2/updates")
+      |> json_response(200)
+
+    media_ids = Enum.map(body["results"], & &1["media_id"])
+    assert media_a.id in media_ids
+    refute media_b.id in media_ids
+  end
+
+  test "project-scoped token cannot fetch updates filtered to another project's media",
+       %{conn: _conn} do
+    project_a = project_fixture()
+    project_b = project_fixture()
+    media_b = media_fixture(%{project_id: project_b.id})
+
+    token_a = api_token_fixture(%{project_id: project_a.id})
+
+    resp =
+      build_conn()
+      |> put_req_header("authorization", "Bearer " <> token_a.value)
+      |> get("/api/v2/updates", %{"slug" => media_b.slug})
+
+    assert json_response(resp, 401) == %{"error" => "media not found"}
+  end
 end

--- a/platform/test/support/fixtures/api_fixtures.ex
+++ b/platform/test/support/fixtures/api_fixtures.ex
@@ -5,36 +5,62 @@ defmodule Platform.APIFixtures do
   """
 
   @doc """
-  Generate a api_token.
+  Generate a project-scoped v2 api_token. If `:project_id` isn't in attrs,
+  a fresh project is created.
   """
   def api_token_fixture(attrs \\ %{}) do
-    {:ok, api_token} =
+    {project, attrs} =
+      case Map.pop(attrs, :project_id) do
+        {nil, attrs} -> {Platform.ProjectsFixtures.project_fixture(), attrs}
+        {id, attrs} -> {Platform.Projects.get_project!(id), attrs}
+      end
+
+    creator = Platform.Accounts.get_auto_account()
+
+    full_attrs =
       attrs
       |> Enum.into(%{
         name: "some name",
-        description: "some description",
-        project_id: Platform.ProjectsFixtures.project_fixture().id,
-        creator_id: Platform.Accounts.get_auto_account().id
+        description: "some description"
       })
-      |> Platform.API.create_api_token()
+
+    {:ok, api_token} = Platform.API.create_api_token(project, creator, full_attrs)
+    api_token
+  end
+
+  @doc """
+  Generate a legacy v1 api_token.
+  """
+  def api_token_fixture_legacy(attrs \\ %{}) do
+    admin = Platform.AccountsFixtures.admin_user_fixture()
+
+    full_attrs =
+      attrs
+      |> Enum.into(%{
+        name: "some name",
+        description: "some description"
+      })
+
+    {:ok, api_token} = Platform.API.create_api_token(nil, admin, full_attrs, legacy: true)
 
     api_token
   end
 
   @doc """
-  Generate a legacy api_token.
+  Generate an instance-wide v2 api_token (admin-created, no project scope).
   """
-  def api_token_fixture_legacy(attrs \\ %{}) do
-    {:ok, api_token} =
+  def api_token_fixture_instance_wide_v2(attrs \\ %{}) do
+    admin = Platform.AccountsFixtures.admin_user_fixture()
+
+    full_attrs =
       attrs
       |> Enum.into(%{
         name: "some name",
         description: "some description",
-        project_id: Platform.ProjectsFixtures.project_fixture().id,
-        creator_id: Platform.Accounts.get_auto_account().id
+        permissions: [:read, :comment, :edit]
       })
-      |> Platform.API.create_api_token(legacy: true)
 
+    {:ok, api_token} = Platform.API.create_api_token(nil, admin, full_attrs)
     api_token
   end
 end


### PR DESCRIPTION
 ### Summary
Allows admins to access v2 API endpoints with instance-wide scope:
1. Admins create v2 tokens from Adminland.
2. Admin v2 tokens grant full v2 API access across every project on the instance.
3. This PR also removes admins' ability to create new v1 tokens (because the v1 scope is a strict subset of the new admin v2 scope, and allowing admins to choose between two token types would be poor UX), though existing v1 tokens still work.

### Motivation
Self-hosting organizations with many investigations need to ensure all media added to Atlos is archived by third-party integrations like the Auto-Archiver. Today, their options are:
1. Ask project Owners to create a new project-scoped v2 token, share the token with instance admins, and create a new integration on a per-project basis. At scale, this approach is not sustainable.
2. Use legacy v1 tokens. These provide admins visibility into what data is added to the platform, but does not enable them to write back to Atlos, a requirement of most archival workflows. 

This PR fills the gap by providing admins with v2 API endpoints with instance-wide scope. 

### Architecture and UX decisions
Three architecture and UX decisions to call out: 
#### Admin-managed tokens are represented as the absence of a project
There were a few reasonable options for representing admin v2 tokens. Specifically, we could 1) add a new is_admin_managed column or 2) derive this from existing columns. I opted for `#2`: This PR encodes admin-management as project_id == nil; the schema gets no new fields. `#1` would further complicate the token schema (legacy tokens would be both `is_legacy` and `is_admin_managed`) and require a migration.

#### No new v1 tokens
This PR removes admins' ability to mint v1 tokens because the UX of choosing between a v1 and v2 token is unacceptably poor: There's no capability v1 provides that instance-wide v2 doesn't, so admins users would be confused why they might want to choose a v1 token. This is also a first step toward eventually deprecating support for v1 endpoints. 

#### Move v1 docs to docs.atlos.org
We currently display some v1 docs on the API Access page of Adminland. To consolidate our documentation on the docs site, and because v1 should be infrequently used, I moved the v1 docs to the docs site.