### PR TITLE
Update role documentation link to direct to instance-level roles, not project-level roles

### DIFF
--- a/platform/lib/platform_web/live/profiles_live/edit_component.ex
+++ b/platform/lib/platform_web/live/profiles_live/edit_component.ex
@@ -133,7 +133,7 @@ defmodule PlatformWeb.ProfilesLive.EditComponent do
               </div>
               <p class="support">
                 For more information about roles on Atlos, view our <a
-                  href="https://docs.atlos.org/investigations/collaboration/#roles--permissions"
+                  href="https://docs.atlos.org/admin/user-management/#instance-level-roles"
                   class="underline"
                   target="blank"
                 >role documentation</a>.


### PR DESCRIPTION
**Expected**
Our link to docs on instance-level roles in the user profile edit modal visible to admins should direct to the docs.atlos.org description of instance-level roles.

**Actual**
The link directs to the docs site's description of project-level roles.

**What Changes**
Swapped the link to direct to the admin documentation on instance-level roles.