### PR TITLE
[WIP] Fix intermittent 500 after login caused by blank global search timing out

### DIFF
--- a/platform/lib/platform/global_search.ex
+++ b/platform/lib/platform/global_search.ex
@@ -270,13 +270,9 @@ defmodule Platform.GlobalSearch do
     }
   end
 
-  # When the query has no searchable characters (blank or punctuation-only),
-  # every ILIKE in the queries above matches all non-NULL rows and every rank
-  # is zero, so the ranked ordering collapses to insertion date anyway — but
-  # computing those ranks forces Postgres to score every row visible to the
-  # user, which can exceed the Task.await_many timeout above (the search
-  # component runs a blank search on every mount). Sort directly on
-  # inserted_at in that case.
+  # A query with no searchable characters matches everything with rank zero,
+  # so ranked ordering would pointlessly score every visible row (and time
+  # out on mount-time blank searches) — sort those queries by recency instead.
   defp order_recents_first(query, ""),
     do: query |> exclude(:order_by) |> order_by([x], desc: x.inserted_at)
 

--- a/platform/lib/platform/global_search.ex
+++ b/platform/lib/platform/global_search.ex
@@ -30,13 +30,14 @@ defmodule Platform.GlobalSearch do
     query_websearch =
       query_cleaned |> String.replace(~r/\s+/, " OR ") |> String.replace(~r/[^a-zA-Z0-9\s\-]/, "")
 
-    # With a blank query, every ILIKE below matches and every rank is zero, so
+    # When the query has no searchable characters (blank or punctuation-only),
+    # every ILIKE below matches all non-NULL rows and every rank is zero, so
     # the ranked ordering collapses to insertion date anyway — but computing
     # those ranks forces Postgres to score every row visible to the user, which
     # can exceed the Task.await_many timeout below (the search component runs a
     # blank search on every mount). Sort directly on inserted_at in that case.
     order_recents_first = fn q ->
-      if query_cleaned == "" do
+      if query_websearch == "" do
         q |> exclude(:order_by) |> order_by([x], desc: x.inserted_at)
       else
         q

--- a/platform/lib/platform/global_search.ex
+++ b/platform/lib/platform/global_search.ex
@@ -270,10 +270,8 @@ defmodule Platform.GlobalSearch do
     }
   end
 
-  # When the query is blank or all punctuation, every row matches and all
-  # ranks are zero — so ordering by rank returns the same rows as ordering by
-  # recency, but only after scoring every visible row, which timed out
-  # mount-time blank searches.
+  # For blank or punctuation-only queries, ranking scores every visible row
+  # just to tie at zero and fall back to recency — it timed out page mounts.
   defp order_recents_first(query, ""),
     do: query |> exclude(:order_by) |> order_by([x], desc: x.inserted_at)
 

--- a/platform/lib/platform/global_search.ex
+++ b/platform/lib/platform/global_search.ex
@@ -270,9 +270,10 @@ defmodule Platform.GlobalSearch do
     }
   end
 
-  # A query with no searchable characters matches every row at rank zero, so
-  # rank ordering returns the same rows as recency ordering — it just scores
-  # the whole visible set first, which timed out mount-time blank searches.
+  # When the query is blank or all punctuation, every row matches and all
+  # ranks are zero — so ordering by rank returns the same rows as ordering by
+  # recency, but only after scoring every visible row, which timed out
+  # mount-time blank searches.
   defp order_recents_first(query, ""),
     do: query |> exclude(:order_by) |> order_by([x], desc: x.inserted_at)
 

--- a/platform/lib/platform/global_search.ex
+++ b/platform/lib/platform/global_search.ex
@@ -30,20 +30,6 @@ defmodule Platform.GlobalSearch do
     query_websearch =
       query_cleaned |> String.replace(~r/\s+/, " OR ") |> String.replace(~r/[^a-zA-Z0-9\s\-]/, "")
 
-    # When the query has no searchable characters (blank or punctuation-only),
-    # every ILIKE below matches all non-NULL rows and every rank is zero, so
-    # the ranked ordering collapses to insertion date anyway — but computing
-    # those ranks forces Postgres to score every row visible to the user, which
-    # can exceed the Task.await_many timeout below (the search component runs a
-    # blank search on every mount). Sort directly on inserted_at in that case.
-    order_recents_first = fn q ->
-      if query_websearch == "" do
-        q |> exclude(:order_by) |> order_by([x], desc: x.inserted_at)
-      else
-        q
-      end
-    end
-
     media_version_query =
       from(
         mv in MediaVersion,
@@ -86,7 +72,7 @@ defmodule Platform.GlobalSearch do
             )
         }
       )
-      |> then(order_recents_first)
+      |> order_recents_first(query_websearch)
 
     media_query =
       from(
@@ -130,7 +116,7 @@ defmodule Platform.GlobalSearch do
             )
         }
       )
-      |> then(order_recents_first)
+      |> order_recents_first(query_websearch)
 
     users_query =
       from(
@@ -201,7 +187,7 @@ defmodule Platform.GlobalSearch do
             )
         }
       )
-      |> then(order_recents_first)
+      |> order_recents_first(query_websearch)
 
     updates_query =
       from(
@@ -245,7 +231,7 @@ defmodule Platform.GlobalSearch do
         }
       )
       |> Platform.Updates.preload_fields()
-      |> then(order_recents_first)
+      |> order_recents_first(query_websearch)
 
     # Run each query in parallel
     [media_version_results, media_results, users_results, projects_results, updates_results] =
@@ -283,4 +269,16 @@ defmodule Platform.GlobalSearch do
       updates: updates_results
     }
   end
+
+  # When the query has no searchable characters (blank or punctuation-only),
+  # every ILIKE in the queries above matches all non-NULL rows and every rank
+  # is zero, so the ranked ordering collapses to insertion date anyway — but
+  # computing those ranks forces Postgres to score every row visible to the
+  # user, which can exceed the Task.await_many timeout above (the search
+  # component runs a blank search on every mount). Sort directly on
+  # inserted_at in that case.
+  defp order_recents_first(query, ""),
+    do: query |> exclude(:order_by) |> order_by([x], desc: x.inserted_at)
+
+  defp order_recents_first(query, _query_websearch), do: query
 end

--- a/platform/lib/platform/global_search.ex
+++ b/platform/lib/platform/global_search.ex
@@ -271,8 +271,9 @@ defmodule Platform.GlobalSearch do
   end
 
   # With no search terms, all ranks are zero, so ranked order is already
-  # recency order. Skipping the ranking avoids scoring every visible row,
-  # which used to time out page mounts.
+  # recency order. Sorting on inserted_at instead lets Postgres serve the
+  # query from an index and stop after `limit` rows rather than visiting
+  # every visible row — which used to time out and 500 the page after login.
   defp order_recents_first(query, ""),
     do: query |> exclude(:order_by) |> order_by([x], desc: x.inserted_at)
 

--- a/platform/lib/platform/global_search.ex
+++ b/platform/lib/platform/global_search.ex
@@ -17,95 +17,8 @@ defmodule Platform.GlobalSearch do
 
   @doc """
   Search all of Atlos for a given query string for the user.
-
-  A blank query returns the most recent items of each type, matching what the
-  full search produces for an empty string (every ILIKE matches, all ranks are
-  zero, so ordering collapses to insertion date) — but via cheap queries that
-  skip the matching and ranking. The full queries degenerate into ranking every
-  row the user can see, and the search component runs a blank search on every
-  mount, so this path must stay cheap.
   """
   defmemo perform_search(query, %User{} = user) when is_binary(query), expires_in: 10000 do
-    if String.trim(query) == "" do
-      recent_items(user)
-    else
-      run_search(query, user)
-    end
-  end
-
-  defp recent_items(%User{} = user) do
-    media_version_query =
-      from(
-        mv in MediaVersion,
-        join: m in assoc(mv, :media),
-        join: p in assoc(m, :project),
-        join: pm in assoc(p, :memberships),
-        on: pm.user_id == ^user.id,
-        where: not is_nil(pm),
-        order_by: [desc: mv.inserted_at],
-        limit: 3,
-        preload: [media: [:project]],
-        select: %{item: mv, exact_match: false, cd_rank: 0}
-      )
-
-    media_query =
-      from(
-        m in Media,
-        join: p in assoc(m, :project),
-        join: pm in assoc(p, :memberships),
-        on: pm.user_id == ^user.id,
-        where: not is_nil(pm),
-        order_by: [desc: m.inserted_at],
-        limit: 3,
-        preload: [:project],
-        select: %{item: m, exact_match: false, cd_rank: 0}
-      )
-
-    projects_query =
-      from(
-        p in Project,
-        join: pm in assoc(p, :memberships),
-        on: pm.user_id == ^user.id,
-        where: not is_nil(pm),
-        order_by: [desc: p.inserted_at],
-        limit: 3,
-        select: %{item: p, exact_match: false, cd_rank: 0}
-      )
-
-    updates_query =
-      from(
-        u in Update,
-        join: m in assoc(u, :media),
-        join: p in assoc(m, :project),
-        join: pm in assoc(p, :memberships),
-        on: pm.user_id == ^user.id,
-        where: not is_nil(pm),
-        order_by: [desc: u.inserted_at],
-        limit: 3,
-        select: %{item: u, exact_match: false, cd_rank: 0}
-      )
-      |> Platform.Updates.preload_fields()
-
-    %{
-      media_versions:
-        Repo.all(media_version_query)
-        |> Enum.filter(fn item -> Permissions.can_view_media_version?(user, item.item) end),
-      media:
-        Repo.all(media_query)
-        |> Enum.filter(fn item -> Permissions.can_view_media?(user, item.item) end),
-      # The full search returns no users for queries under three characters,
-      # so a blank query lists none either
-      users: [],
-      projects:
-        Repo.all(projects_query)
-        |> Enum.filter(fn item -> Permissions.can_view_project?(user, item.item) end),
-      updates:
-        Repo.all(updates_query)
-        |> Enum.filter(fn item -> Permissions.can_view_update?(user, item.item) end)
-    }
-  end
-
-  defp run_search(query, %User{} = user) do
     query_lower_raw = String.trim(query) |> String.downcase()
 
     query_cleaned =
@@ -116,6 +29,19 @@ defmodule Platform.GlobalSearch do
 
     query_websearch =
       query_cleaned |> String.replace(~r/\s+/, " OR ") |> String.replace(~r/[^a-zA-Z0-9\s\-]/, "")
+
+    # With a blank query, every ILIKE below matches and every rank is zero, so
+    # the ranked ordering collapses to insertion date anyway — but computing
+    # those ranks forces Postgres to score every row visible to the user, which
+    # can exceed the Task.await_many timeout below (the search component runs a
+    # blank search on every mount). Sort directly on inserted_at in that case.
+    order_recents_first = fn q ->
+      if query_cleaned == "" do
+        q |> exclude(:order_by) |> order_by([x], desc: x.inserted_at)
+      else
+        q
+      end
+    end
 
     media_version_query =
       from(
@@ -159,6 +85,7 @@ defmodule Platform.GlobalSearch do
             )
         }
       )
+      |> then(order_recents_first)
 
     media_query =
       from(
@@ -202,6 +129,7 @@ defmodule Platform.GlobalSearch do
             )
         }
       )
+      |> then(order_recents_first)
 
     users_query =
       from(
@@ -272,6 +200,7 @@ defmodule Platform.GlobalSearch do
             )
         }
       )
+      |> then(order_recents_first)
 
     updates_query =
       from(
@@ -315,6 +244,7 @@ defmodule Platform.GlobalSearch do
         }
       )
       |> Platform.Updates.preload_fields()
+      |> then(order_recents_first)
 
     # Run each query in parallel
     [media_version_results, media_results, users_results, projects_results, updates_results] =

--- a/platform/lib/platform/global_search.ex
+++ b/platform/lib/platform/global_search.ex
@@ -18,17 +18,91 @@ defmodule Platform.GlobalSearch do
   @doc """
   Search all of Atlos for a given query string for the user.
 
-  A blank query returns no results without touching the database: with an
-  empty string, every ILIKE clause below becomes `ILIKE '%%'` and each query
-  degenerates into ranking and sorting every row the user can see. The search
-  component runs a search on every mount, so this path must stay cheap.
+  A blank query returns the most recent items of each type, matching what the
+  full search produces for an empty string (every ILIKE matches, all ranks are
+  zero, so ordering collapses to insertion date) — but via cheap queries that
+  skip the matching and ranking. The full queries degenerate into ranking every
+  row the user can see, and the search component runs a blank search on every
+  mount, so this path must stay cheap.
   """
   defmemo perform_search(query, %User{} = user) when is_binary(query), expires_in: 10000 do
     if String.trim(query) == "" do
-      %{media_versions: [], media: [], users: [], projects: [], updates: []}
+      recent_items(user)
     else
       run_search(query, user)
     end
+  end
+
+  defp recent_items(%User{} = user) do
+    media_version_query =
+      from(
+        mv in MediaVersion,
+        join: m in assoc(mv, :media),
+        join: p in assoc(m, :project),
+        join: pm in assoc(p, :memberships),
+        on: pm.user_id == ^user.id,
+        where: not is_nil(pm),
+        order_by: [desc: mv.inserted_at],
+        limit: 3,
+        preload: [media: [:project]],
+        select: %{item: mv, exact_match: false, cd_rank: 0}
+      )
+
+    media_query =
+      from(
+        m in Media,
+        join: p in assoc(m, :project),
+        join: pm in assoc(p, :memberships),
+        on: pm.user_id == ^user.id,
+        where: not is_nil(pm),
+        order_by: [desc: m.inserted_at],
+        limit: 3,
+        preload: [:project],
+        select: %{item: m, exact_match: false, cd_rank: 0}
+      )
+
+    projects_query =
+      from(
+        p in Project,
+        join: pm in assoc(p, :memberships),
+        on: pm.user_id == ^user.id,
+        where: not is_nil(pm),
+        order_by: [desc: p.inserted_at],
+        limit: 3,
+        select: %{item: p, exact_match: false, cd_rank: 0}
+      )
+
+    updates_query =
+      from(
+        u in Update,
+        join: m in assoc(u, :media),
+        join: p in assoc(m, :project),
+        join: pm in assoc(p, :memberships),
+        on: pm.user_id == ^user.id,
+        where: not is_nil(pm),
+        order_by: [desc: u.inserted_at],
+        limit: 3,
+        select: %{item: u, exact_match: false, cd_rank: 0}
+      )
+      |> Platform.Updates.preload_fields()
+
+    %{
+      media_versions:
+        Repo.all(media_version_query)
+        |> Enum.filter(fn item -> Permissions.can_view_media_version?(user, item.item) end),
+      media:
+        Repo.all(media_query)
+        |> Enum.filter(fn item -> Permissions.can_view_media?(user, item.item) end),
+      # The full search returns no users for queries under three characters,
+      # so a blank query lists none either
+      users: [],
+      projects:
+        Repo.all(projects_query)
+        |> Enum.filter(fn item -> Permissions.can_view_project?(user, item.item) end),
+      updates:
+        Repo.all(updates_query)
+        |> Enum.filter(fn item -> Permissions.can_view_update?(user, item.item) end)
+    }
   end
 
   defp run_search(query, %User{} = user) do

--- a/platform/lib/platform/global_search.ex
+++ b/platform/lib/platform/global_search.ex
@@ -270,8 +270,9 @@ defmodule Platform.GlobalSearch do
     }
   end
 
-  # For blank or punctuation-only queries, ranking scores every visible row
-  # just to tie at zero and fall back to recency — it timed out page mounts.
+  # With no search terms, all ranks are zero, so ranked order is already
+  # recency order. Skipping the ranking avoids scoring every visible row,
+  # which used to time out page mounts.
   defp order_recents_first(query, ""),
     do: query |> exclude(:order_by) |> order_by([x], desc: x.inserted_at)
 

--- a/platform/lib/platform/global_search.ex
+++ b/platform/lib/platform/global_search.ex
@@ -270,10 +270,10 @@ defmodule Platform.GlobalSearch do
     }
   end
 
-  # With no search terms, all ranks are zero, so ranked order is already
-  # recency order. Sorting on inserted_at instead lets Postgres serve the
-  # query from an index and stop after `limit` rows rather than visiting
-  # every visible row — which used to time out and 500 the page after login.
+  # A blank search runs on every page mount and used to time out with a
+  # 500 right after login. With no terms every row ranks zero, so
+  # ordering by recency returns the same rows as the ranked order, but
+  # lets Postgres use an index and stop after LIMIT instead of scanning.
   defp order_recents_first(query, ""),
     do: query |> exclude(:order_by) |> order_by([x], desc: x.inserted_at)
 

--- a/platform/lib/platform/global_search.ex
+++ b/platform/lib/platform/global_search.ex
@@ -270,9 +270,9 @@ defmodule Platform.GlobalSearch do
     }
   end
 
-  # A query with no searchable characters matches everything with rank zero,
-  # so ranked ordering would pointlessly score every visible row (and time
-  # out on mount-time blank searches) — sort those queries by recency instead.
+  # A query with no searchable characters matches every row at rank zero, so
+  # rank ordering returns the same rows as recency ordering — it just scores
+  # the whole visible set first, which timed out mount-time blank searches.
   defp order_recents_first(query, ""),
     do: query |> exclude(:order_by) |> order_by([x], desc: x.inserted_at)
 

--- a/platform/lib/platform/global_search.ex
+++ b/platform/lib/platform/global_search.ex
@@ -17,8 +17,21 @@ defmodule Platform.GlobalSearch do
 
   @doc """
   Search all of Atlos for a given query string for the user.
+
+  A blank query returns no results without touching the database: with an
+  empty string, every ILIKE clause below becomes `ILIKE '%%'` and each query
+  degenerates into ranking and sorting every row the user can see. The search
+  component runs a search on every mount, so this path must stay cheap.
   """
   defmemo perform_search(query, %User{} = user) when is_binary(query), expires_in: 10000 do
+    if String.trim(query) == "" do
+      %{media_versions: [], media: [], users: [], projects: [], updates: []}
+    else
+      run_search(query, user)
+    end
+  end
+
+  defp run_search(query, %User{} = user) do
     query_lower_raw = String.trim(query) |> String.downcase()
 
     query_cleaned =

--- a/platform/priv/repo/migrations/20260830120000_add_media_versions_inserted_at_index.exs
+++ b/platform/priv/repo/migrations/20260830120000_add_media_versions_inserted_at_index.exs
@@ -1,0 +1,9 @@
+defmodule Platform.Repo.Migrations.AddMediaVersionsInsertedAtIndex do
+  use Ecto.Migration
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def change do
+    create index(:media_versions, [:inserted_at], concurrently: true)
+  end
+end


### PR DESCRIPTION
## Problem

Logging in intermittently returned a 500. The crash was an `** (exit) time out` from `Task.await_many(..., 5000)` inside `Platform.GlobalSearch.perform_search/2`, raised during the first page render after login (e.g. `NotificationsLive`), via `SearchComponent.update/2`.

Root cause: the global search component (rendered in the nav on every page) runs a search with an **empty query** on every mount. With no search terms, every `ILIKE` clause becomes `ILIKE '%%'` and matches every row the user can see, while `ORDER BY ts_rank_cd(...)` forces Postgres to score all of those rows before it can apply `LIMIT 3` — an unindexable full rank-and-sort over up to five tables in parallel, racing a hard 5-second deadline. Login is the worst moment: the per-user memoize cache is always cold, and the crash happens during the plain HTTP render, so it surfaces as a 500 (mid-session, the same crash just looks like a LiveView reconnect).

## Fix

- **Blank/punctuation-only queries sort by `inserted_at DESC` instead of rank** (`order_recents_first/2`). This is behavior-preserving: with no terms, every row ties at rank zero, so the ranked ordering already collapsed to recency — the palette shows the same "recent items". Sorting on a plain column lets Postgres serve the query from an index and stop after `LIMIT` rows instead of visiting every visible row. Real queries are byte-for-byte unchanged.
- **New index on `media_versions.inserted_at`** (built `concurrently`) — the one large table in this path that had no recency index.
- `users_query` is left untouched because blank queries already return no users via the existing `< 3`-character cutoff.

## Test outcome (local reproduction)

Reproduced the bug and verified the fix end-to-end against a dev instance seeded to production-like scale (**3.0M media_versions, 500k media, 500k updates**, all visible to the test user), running the real login flow over HTTP:

| Code | `GET /notifications` after login | In-app `perform_search("", user)` |
|---|---|---|
| `main` | **HTTP 500 after ~5.2s** | crashes: `Task.await_many` timeout at ~5.0s |
| this branch | **HTTP 200** (~0.1s warm) | ~1.9s total; all four search queries < 1 ms |

The 500 on `main` produced the identical exception signature to the production report (five tasks, 5000 ms deadline, killed during the post-login render). With the fix, `EXPLAIN ANALYZE` shows each blank-path query doing a backward index scan that reads 3 rows (~29 buffers, ~0.1 ms) instead of a parallel seq scan over all ~3M rows (~60k buffers); returned rows are identical. Verification-count instrumentation confirmed the old ordering evaluated the rank expression once per visible row (300,000/300,000 on a test table) vs. 3/300,000 with the fix.

Caveats: reproduced on Postgres 16 / Elixir 1.14 locally (prod builds use newer Elixir); the fixed path's remaining ~1.9s cold time is the pre-existing per-result permission-check layer, which is independent of table size.

## Marked WIP — known follow-ups not in this PR

- A typed short query (e.g. one character) still runs the full ranked scan and can hit the same 5s deadline from `handle_event("search", ...)`; graceful degradation (`Task.yield_many` partial results or `assign_async`) is the planned fix for the crash *class*.
- No regression test yet (`GlobalSearch` currently has no test coverage at all); a blank-query behavior test is planned.
- Possible cheap additions flagged in review: `projects.inserted_at` + `media.project_id` indexes, and an `id` tiebreaker on the recency ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KEMrXKYjmk6iVUby9bRsCu

---
_Generated by [Claude Code](https://claude.ai/code/session_01KEMrXKYjmk6iVUby9bRsCu)_